### PR TITLE
Change to Debounce Watcher.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,13 @@ homepage = "https://github.com/emoon/dynamic_reload"
 documentation = "http://prodbg.com/dynamic_reload/dynamic_reload/index.html"
 build = "build.rs"
 
+[features]
+# Don't add timestamps to shadow copy.
+no-timestamps = []
+
+# Don't unload old library.
+no-unload = []
+
 [dependencies]
 notify = "4.0.*"
 libc = "0.2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -312,7 +312,8 @@ impl<'a> DynamicReload<'a> {
 
     fn should_reload(reload_path: &PathBuf, lib: &Lib) -> bool {
         if let Some(p) = lib.original_path.as_ref() {
-            if reload_path.to_str().unwrap().contains(p.to_str().unwrap()) {
+            // Check if file names match.
+            if reload_path.file_name() == p.file_name() {
                 return true;
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -417,11 +417,11 @@ impl<'a> DynamicReload<'a> {
             if let Ok(file) = fs::metadata(src) {
                 let len = file.len();
                 if len > 0 {
-                    return match fs::copy(&src, &dest) {
-                        Ok(_)  => Ok(()),
-                        Err(e) => Err(Error::Copy(e, src.to_path_buf(), dest.to_path_buf()))
+                    // ignore copy errors, library file might be locked by the compiler
+                    match fs::copy(&src, &dest) {
+                        Ok(_)  => return Ok(()),
+                        Err(_) => (),
                     };
-                    //println!("Copy from {} {}", src.to_str().unwrap(), dest.to_str().unwrap());
                 }
             }
 


### PR DESCRIPTION
Also ignore copy errors so copy can be retried 10 times.

Compare filename and extensions, to ignore .dll.exp file changes.