### PR TITLE
Updated libloading to 0.7.2, changed API to match

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dynamic_reload"
-version = "0.4.0"
+version = "0.5.0"
 license = "MIT/Apache-2.0"
 authors = ["Daniel Collin <daniel@collin.com>"]
 description = "Cross-platform dynamic reloading of shared libraries"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,6 @@ no-unload = []
 [dependencies]
 notify = "4.0.*"
 libc = "0.2.0"
-libloading = "0.5.*"
+libloading = "0.7.*"
 tempdir = "0.3"
 

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -51,7 +51,7 @@ fn main() {
     );
 
     // test_shared is generated in build.rs
-    match reload_handler.add_library("test_shared", PlatformName::Yes) {
+    match unsafe { reload_handler.add_library("test_shared", PlatformName::Yes) } {
         Ok(lib) => plugs.add_plugin(&lib),
         Err(e) => {
             println!("Unable to load dynamic lib, err {:?}", e);
@@ -62,7 +62,9 @@ fn main() {
     // While this is running (printing a constant number) change return value in file src/test_shared.rs
     // build the project with cargo build and notice that this code will now return the new value
     loop {
-        reload_handler.update(Plugins::reload_callback, &mut plugs);
+        unsafe {
+            reload_handler.update(Plugins::reload_callback, &mut plugs);
+        }
 
         if plugs.plugins.len() > 0 {
             // In a real program you want to cache the symbol and not do it every time if your

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 #[derive(Debug)]
 pub enum Error {
     /// Loading a library failed
-    Load(io::Error),
+    Load(libloading::Error),
     /// File copy operation failed
     Copy(io::Error, PathBuf, PathBuf),
     /// Timeout of file copy happend.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,7 +168,11 @@ impl<'a> DynamicReload {
     /// add_library("test_lib", PlatformName::Yes)
     /// ```
     ///
-    pub fn add_library(&mut self, name: &str, name_format: PlatformName) -> Result<Arc<Lib>> {
+    pub unsafe fn add_library(
+        &mut self,
+        name: &str,
+        name_format: PlatformName,
+    ) -> Result<Arc<Lib>> {
         match Self::try_load_library(self, name, name_format) {
             Ok(lib) => {
                 if let Some(w) = self.watcher.as_mut() {
@@ -220,7 +224,7 @@ impl<'a> DynamicReload {
     /// }
     /// ```
     ///
-    pub fn update<F, T>(&mut self, ref update_call: F, data: &mut T)
+    pub unsafe fn update<F, T>(&mut self, ref update_call: F, data: &mut T)
     where
         F: Fn(&mut T, UpdateState, Option<&Arc<Lib>>),
     {
@@ -235,7 +239,7 @@ impl<'a> DynamicReload {
         }
     }
 
-    fn reload_libs<F, T>(&mut self, file_path: &PathBuf, ref update_call: F, data: &mut T)
+    unsafe fn reload_libs<F, T>(&mut self, file_path: &PathBuf, ref update_call: F, data: &mut T)
     where
         F: Fn(&mut T, UpdateState, Option<&Arc<Lib>>),
     {
@@ -247,7 +251,7 @@ impl<'a> DynamicReload {
         }
     }
 
-    fn reload_lib<F, T>(
+    unsafe fn reload_lib<F, T>(
         &mut self,
         index: usize,
         file_path: &PathBuf,
@@ -272,14 +276,14 @@ impl<'a> DynamicReload {
         }
     }
 
-    fn try_load_library(&self, name: &str, name_format: PlatformName) -> Result<Arc<Lib>> {
+    unsafe fn try_load_library(&self, name: &str, name_format: PlatformName) -> Result<Arc<Lib>> {
         match Self::search_dirs(self, name, name_format) {
             Some(path) => Self::load_library(self, &path),
             None => Err(Error::Find(name.into())),
         }
     }
 
-    fn load_library(&self, full_path: &PathBuf) -> Result<Arc<Lib>> {
+    unsafe fn load_library(&self, full_path: &PathBuf) -> Result<Arc<Lib>> {
         let path;
         let original_path;
 
@@ -295,7 +299,7 @@ impl<'a> DynamicReload {
         Self::init_library(original_path, path)
     }
 
-    fn init_library(org_path: Option<PathBuf>, path: PathBuf) -> Result<Arc<Lib>> {
+    unsafe fn init_library(org_path: Option<PathBuf>, path: PathBuf) -> Result<Arc<Lib>> {
         match Library::new(&path) {
             Ok(l) => Ok(Arc::new(Lib {
                 original_path: org_path,
@@ -631,27 +635,35 @@ mod tests {
     #[test]
     fn test_add_library_fail() {
         let mut dr = DynamicReload::new(None, None, Search::Default);
-        assert!(dr
-            .add_library("wont_find_this_lib", PlatformName::No)
-            .is_err());
+        unsafe {
+            assert!(dr
+                .add_library("wont_find_this_lib", PlatformName::No)
+                .is_err());
+        }
     }
 
     #[test]
     fn test_add_shared_lib_ok() {
         let mut dr = DynamicReload::new(None, None, Search::Default);
-        assert!(dr.add_library("test_shared", PlatformName::Yes).is_ok());
+        unsafe {
+            assert!(dr.add_library("test_shared", PlatformName::Yes).is_ok());
+        }
     }
 
     #[test]
     fn test_add_shared_lib_search_paths() {
         let mut dr = DynamicReload::new(Some(vec!["../..", "../test"]), None, Search::Default);
-        assert!(dr.add_library("test_shared", PlatformName::Yes).is_ok());
+        unsafe {
+            assert!(dr.add_library("test_shared", PlatformName::Yes).is_ok());
+        }
     }
 
     #[test]
     fn test_add_shared_lib_fail_load() {
         let mut dr = DynamicReload::new(None, None, Search::Default);
-        assert!(dr.add_library("Cargo.toml", PlatformName::No).is_err());
+        unsafe {
+            assert!(dr.add_library("Cargo.toml", PlatformName::No).is_err());
+        }
     }
 
     #[test]
@@ -672,13 +684,16 @@ mod tests {
         let path1 = "../..".to_owned();
         let path2 = "../test".to_owned();
         let mut dr = DynamicReload::new(Some(vec![&path1, &path2]), None, Search::Default);
-        assert!(dr.add_library("test_shared", PlatformName::Yes).is_ok());
+        unsafe {
+            assert!(dr.add_library("test_shared", PlatformName::Yes).is_ok());
+        }
     }
 
     #[test]
     fn test_add_shared_update() {
         let mut notify_callback = TestNotifyCallback::default();
         let target_path = get_test_shared_lib();
+
         let mut dest_path = Path::new(&target_path).to_path_buf();
 
         let mut dr = DynamicReload::new(None, Some("target/debug"), Search::Default);
@@ -687,10 +702,14 @@ mod tests {
 
         fs::copy(&target_path, &dest_path).unwrap();
 
-        assert!(dr.add_library("test_shared", PlatformName::Yes).is_ok());
+        unsafe {
+            assert!(dr.add_library("test_shared", PlatformName::Yes).is_ok());
+        }
 
         for i in 0..10 {
-            dr.update(TestNotifyCallback::update_call, &mut notify_callback);
+            unsafe {
+                dr.update(TestNotifyCallback::update_call, &mut notify_callback);
+            }
 
             if i == 2 {
                 fs::copy(&dest_path, &target_path).unwrap();
@@ -725,10 +744,14 @@ mod tests {
         // Wait a while before open the file. Not sure why this is needed.
         thread::sleep(Duration::from_millis(100));
 
-        assert!(dr.add_library(&test_file, PlatformName::No).is_ok());
+        unsafe {
+            assert!(dr.add_library(&test_file, PlatformName::No).is_ok());
+        }
 
         for i in 0..10 {
-            dr.update(TestNotifyCallback::update_call, &mut notify_callback);
+            unsafe {
+                dr.update(TestNotifyCallback::update_call, &mut notify_callback);
+            }
 
             if i == 2 {
                 // Copy a non-shared lib to test the lib handles a broken "lib"
@@ -746,7 +769,7 @@ mod tests {
     #[test]
     fn test_lib_equals_true() {
         let mut dr = DynamicReload::new(None, None, Search::Default);
-        let lib = dr.add_library("test_shared", PlatformName::Yes).unwrap();
+        let lib = unsafe { dr.add_library("test_shared", PlatformName::Yes).unwrap() };
         let lib2 = lib.clone();
         assert!(lib == lib2);
     }
@@ -768,8 +791,8 @@ mod tests {
         let _ = DynamicReload::try_copy(&target_path, &dest_path);
         thread::sleep(Duration::from_millis(100));
 
-        let lib0 = dr.add_library(&test_file, PlatformName::No).unwrap();
-        let lib1 = dr.add_library("test_shared", PlatformName::Yes).unwrap();
+        let lib0 = unsafe { dr.add_library(&test_file, PlatformName::No).unwrap() };
+        let lib1 = unsafe { dr.add_library("test_shared", PlatformName::Yes).unwrap() };
 
         assert!(lib0 != lib1);
     }


### PR DESCRIPTION
In order to avoid version conflicts with the Vulkan library 'ash' I needed to update libloading to 0.7.x

This update changed one error that is returned, which adapted quite easily.
Also the `Library::new(...)` function of libloading is now marked unsafe as the library can not give guarantees about the soundness of the loaded library and its initialization code that will be executed.
So I think it is best to propagate the unsafe-ness to the user of dynamic_reload since only they can make sure the loaded dylib is safe and sound.

I just put unsafe blocks in all tests and examples, and now they pass. It also works in my personal use-case quite well. Though probably best if someone reviews this.

Also this should probably be a 0.x version bump for dynamic_reload due to API changes? I have not included that yet, and have no experience with managing SemVer.