### PR TITLE
Update libloading to 0.8.*

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,5 @@ no-unload = []
 
 [dependencies]
 notify-debouncer-mini = "0.2.0"
-libloading = "0.7.*"
+libloading = "0.8.*"
 tempfile = "3"


### PR DESCRIPTION
Libloading got updated. To be able to use both libloading and dynamic_reload in the same project they need to be the same version.

dynamic_reload compiles and works correctly after this update in my project :)